### PR TITLE
Remove toBoolean() calls around getOption() for boolean options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 
 php:
   - 5.6
+  - 7.0
   - nightly
   - hhvm
   - hhvm-nightly
@@ -10,6 +11,7 @@ matrix:
   allow_failures:
     - php: hhvm
     - php: hhvm-nightly
+    - php: nightly
   
 install:
   - curl -s http://getcomposer.org/installer | php -d date.timezone="Europe/Berlin" -- --install-dir=./bin/

--- a/composer.json
+++ b/composer.json
@@ -24,17 +24,17 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=5.6.0",
-        "beberlei/assert": "2.4",
-        "egulias/email-validator": "1.2.*",
-        "fzaninotto/faker": "1.5.*",
-        "mtdowling/jmespath.php": "2.2.*",
-        "ramsey/uuid": "3.0.*",
-        "symfony/console": "2.7.*",
-        "symfony/filesystem": "2.7.*",
-        "twig/twig": "1.22.*"
+        "beberlei/assert": "~2.4.0",
+        "egulias/email-validator": "~1.2",
+        "fzaninotto/faker": "~1.5",
+        "mtdowling/jmespath.php": "~2.2",
+        "ramsey/uuid": "~3.1",
+        "symfony/console": "~2.7",
+        "symfony/filesystem": "~2.7",
+        "twig/twig": "~1.23.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "5.0.*",
+        "phpunit/phpunit": ">5.0.0",
         "phpmd/phpmd": "2.3.*",
         "squizlabs/php_codesniffer": "2.3.*",
         "mockery/mockery": "0.9.*",

--- a/composer.json
+++ b/composer.json
@@ -49,15 +49,12 @@
     },
     "scripts": {
         "test": [
-            "echo \"\nRunning unit tests ...\n\"",
             "./vendor/bin/phpunit tests"
         ],
         "code-sniffer": [
-            "echo \"\nRunning codesniffer to check for PSR-2 compatibility ...\n\"",
             "./vendor/bin/phpcs --extensions=php --standard=psr2 ./src/ ./tests"
         ],
         "api-doc": [
-            "echo \"\nRunning Sami to generate docs ...\n\"",
             "if [ -d ./build/docs ]; then rm -rf ./build/docs; fi",
             "vendor/sami/sami/sami.php --ansi update config/sami.php"
         ],

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "7db05f0db432940c112075c0ff56c887",
-    "content-hash": "359eb39b2ecdbd9f460628e1a18ef7c9",
+    "hash": "4b42b9b7d23759e90e569a1bd47ac542",
+    "content-hash": "62d4623ca36c8250013729d623b68742",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -116,16 +116,16 @@
         },
         {
             "name": "egulias/email-validator",
-            "version": "1.2.10",
+            "version": "1.2.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/egulias/EmailValidator.git",
-                "reference": "de448a30fa78f2dc93889be529e875a13c6034ac"
+                "reference": "04c6cdf9871140b80947c87db7770c0dd9c75c7c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/de448a30fa78f2dc93889be529e875a13c6034ac",
-                "reference": "de448a30fa78f2dc93889be529e875a13c6034ac",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/04c6cdf9871140b80947c87db7770c0dd9c75c7c",
+                "reference": "04c6cdf9871140b80947c87db7770c0dd9c75c7c",
                 "shasum": ""
             },
             "require": {
@@ -165,7 +165,7 @@
                 "validation",
                 "validator"
             ],
-            "time": "2015-10-11 22:34:23"
+            "time": "2015-11-11 03:28:32"
         },
         {
             "name": "fzaninotto/faker",
@@ -276,16 +276,16 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "3.0.1",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "3c84b9e2965a5fa666dec8617a3a66a8179c6ca8"
+                "reference": "3cc2dd253e296ce05f99635b2f633048adfbaa96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/3c84b9e2965a5fa666dec8617a3a66a8179c6ca8",
-                "reference": "3c84b9e2965a5fa666dec8617a3a66a8179c6ca8",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/3cc2dd253e296ce05f99635b2f633048adfbaa96",
+                "reference": "3cc2dd253e296ce05f99635b2f633048adfbaa96",
                 "shasum": ""
             },
             "require": {
@@ -342,29 +342,30 @@
                 "identifier",
                 "uuid"
             ],
-            "time": "2015-10-21 16:27:25"
+            "time": "2015-12-17 15:21:44"
         },
         {
             "name": "symfony/console",
-            "version": "v2.7.6",
+            "version": "v2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "5efd632294c8320ea52492db22292ff853a43766"
+                "reference": "d232bfc100dfd32b18ccbcab4bcc8f28697b7e41"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/5efd632294c8320ea52492db22292ff853a43766",
-                "reference": "5efd632294c8320ea52492db22292ff853a43766",
+                "url": "https://api.github.com/repos/symfony/console/zipball/d232bfc100dfd32b18ccbcab4bcc8f28697b7e41",
+                "reference": "d232bfc100dfd32b18ccbcab4bcc8f28697b7e41",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9"
+                "php": ">=5.3.9",
+                "symfony/polyfill-mbstring": "~1.0"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/event-dispatcher": "~2.1",
-                "symfony/process": "~2.1"
+                "symfony/event-dispatcher": "~2.1|~3.0.0",
+                "symfony/process": "~2.1|~3.0.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
@@ -374,13 +375,16 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Console\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -398,20 +402,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2015-10-20 14:38:46"
+            "time": "2015-11-30 12:35:10"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.7.6",
+            "version": "v2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "56fd6df73be859323ff97418d97edc1d756df6df"
+                "reference": "3e661a0d521ac67496515fa6e6704bd61bcfff60"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/56fd6df73be859323ff97418d97edc1d756df6df",
-                "reference": "56fd6df73be859323ff97418d97edc1d756df6df",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/3e661a0d521ac67496515fa6e6704bd61bcfff60",
+                "reference": "3e661a0d521ac67496515fa6e6704bd61bcfff60",
                 "shasum": ""
             },
             "require": {
@@ -420,13 +424,16 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Filesystem\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -444,20 +451,76 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2015-10-18 20:23:18"
+            "time": "2015-11-23 10:19:46"
         },
         {
-            "name": "twig/twig",
-            "version": "v1.22.3",
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/twigphp/Twig.git",
-                "reference": "ebfc36b7e77b0c1175afe30459cf943010245540"
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "0b6a8940385311a24e060ec1fe35680e17c74497"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/ebfc36b7e77b0c1175afe30459cf943010245540",
-                "reference": "ebfc36b7e77b0c1175afe30459cf943010245540",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/0b6a8940385311a24e060ec1fe35680e17c74497",
+                "reference": "0b6a8940385311a24e060ec1fe35680e17c74497",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2015-11-04 20:28:58"
+        },
+        {
+            "name": "twig/twig",
+            "version": "v1.23.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twigphp/Twig.git",
+                "reference": "d9b6333ae8dd2c8e3fd256e127548def0bc614c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/d9b6333ae8dd2c8e3fd256e127548def0bc614c6",
+                "reference": "d9b6333ae8dd2c8e3fd256e127548def0bc614c6",
                 "shasum": ""
             },
             "require": {
@@ -470,7 +533,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.22-dev"
+                    "dev-master": "1.23-dev"
                 }
             },
             "autoload": {
@@ -505,7 +568,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2015-10-13 07:07:02"
+            "time": "2015-11-05 12:49:06"
         }
     ],
     "packages-dev": [
@@ -821,16 +884,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "d8093b631a31628342d0703764935f8bac2c56b1"
+                "reference": "e3abefcd7f106677fd352cd7c187d6c969aa9ddc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/d8093b631a31628342d0703764935f8bac2c56b1",
-                "reference": "d8093b631a31628342d0703764935f8bac2c56b1",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/e3abefcd7f106677fd352cd7c187d6c969aa9ddc",
+                "reference": "e3abefcd7f106677fd352cd7c187d6c969aa9ddc",
                 "shasum": ""
             },
             "require": {
@@ -859,7 +922,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2015-10-05 15:07:09"
+            "time": "2015-11-07 22:20:37"
         },
         {
             "name": "nikic/php-parser",
@@ -1122,16 +1185,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "3.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "c84f05be256cd7c9d2340b26f7995b4afbf8787b"
+                "reference": "f7bb5cddf4ffe113eeb737b05241adb947b43f9d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c84f05be256cd7c9d2340b26f7995b4afbf8787b",
-                "reference": "c84f05be256cd7c9d2340b26f7995b4afbf8787b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f7bb5cddf4ffe113eeb737b05241adb947b43f9d",
+                "reference": "f7bb5cddf4ffe113eeb737b05241adb947b43f9d",
                 "shasum": ""
             },
             "require": {
@@ -1180,7 +1243,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:51:05"
+            "time": "2015-11-12 21:08:20"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1362,16 +1425,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.0.8",
+            "version": "5.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "97fb2503cf8caca9d768fde3cca2ab147b9e7030"
+                "reference": "c047ff05d2279404af9a7e89e2a7151c32c88022"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/97fb2503cf8caca9d768fde3cca2ab147b9e7030",
-                "reference": "97fb2503cf8caca9d768fde3cca2ab147b9e7030",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c047ff05d2279404af9a7e89e2a7151c32c88022",
+                "reference": "c047ff05d2279404af9a7e89e2a7151c32c88022",
                 "shasum": ""
             },
             "require": {
@@ -1387,7 +1450,7 @@
                 "phpunit/php-file-iterator": "~1.4",
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": ">=1.0.6",
-                "phpunit/phpunit-mock-objects": ">=3.0",
+                "phpunit/phpunit-mock-objects": ">=3.0.5",
                 "sebastian/comparator": "~1.1",
                 "sebastian/diff": "~1.2",
                 "sebastian/environment": "~1.3",
@@ -1406,7 +1469,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0.x-dev"
+                    "dev-master": "5.1.x-dev"
                 }
             },
             "autoload": {
@@ -1432,20 +1495,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-23 06:50:01"
+            "time": "2015-12-10 07:54:54"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "3.0.3",
+            "version": "3.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "382c729a52b7ef682e94c73fd6868f5ee8116ba7"
+                "reference": "49bc700750196c04dd6bc2c4c99cb632b893836b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/382c729a52b7ef682e94c73fd6868f5ee8116ba7",
-                "reference": "382c729a52b7ef682e94c73fd6868f5ee8116ba7",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/49bc700750196c04dd6bc2c4c99cb632b893836b",
+                "reference": "49bc700750196c04dd6bc2c4c99cb632b893836b",
                 "shasum": ""
             },
             "require": {
@@ -1488,7 +1551,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-18 07:55:54"
+            "time": "2015-12-08 08:47:06"
         },
         {
             "name": "pimple/pimple",
@@ -1766,28 +1829,28 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "1.3.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "863df9687835c62aa423a22412d26fa2ebde3fd3"
+                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/863df9687835c62aa423a22412d26fa2ebde3fd3",
-                "reference": "863df9687835c62aa423a22412d26fa2ebde3fd3",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "~4.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -1810,24 +1873,24 @@
                 }
             ],
             "description": "Diff implementation",
-            "homepage": "http://www.github.com/sebastianbergmann/diff",
+            "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
                 "diff"
             ],
-            "time": "2015-02-22 15:13:53"
+            "time": "2015-12-08 07:14:41"
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.2",
+            "version": "1.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "6324c907ce7a52478eeeaede764f48733ef5ae44"
+                "reference": "6e7133793a8e5a5714a551a8324337374be209df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6324c907ce7a52478eeeaede764f48733ef5ae44",
-                "reference": "6324c907ce7a52478eeeaede764f48733ef5ae44",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6e7133793a8e5a5714a551a8324337374be209df",
+                "reference": "6e7133793a8e5a5714a551a8324337374be209df",
                 "shasum": ""
             },
             "require": {
@@ -1864,7 +1927,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2015-08-03 06:14:51"
+            "time": "2015-12-02 08:37:27"
         },
         {
             "name": "sebastian/exporter",
@@ -1985,16 +2048,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "994d4a811bafe801fb06dccbee797863ba2792ba"
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/994d4a811bafe801fb06dccbee797863ba2792ba",
-                "reference": "994d4a811bafe801fb06dccbee797863ba2792ba",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
                 "shasum": ""
             },
             "require": {
@@ -2034,7 +2097,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-06-21 08:04:50"
+            "time": "2015-11-11 19:50:13"
         },
         {
             "name": "sebastian/resource-operations",
@@ -2189,32 +2252,35 @@
         },
         {
             "name": "symfony/config",
-            "version": "v2.7.6",
+            "version": "v2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "831f88908b51b9ce945f5e6f402931d1ac544423"
+                "reference": "f21c97aec1b5302d2dc0d17047ea8f4e4ff93aae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/831f88908b51b9ce945f5e6f402931d1ac544423",
-                "reference": "831f88908b51b9ce945f5e6f402931d1ac544423",
+                "url": "https://api.github.com/repos/symfony/config/zipball/f21c97aec1b5302d2dc0d17047ea8f4e4ff93aae",
+                "reference": "f21c97aec1b5302d2dc0d17047ea8f4e4ff93aae",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.9",
-                "symfony/filesystem": "~2.3"
+                "symfony/filesystem": "~2.3|~3.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Config\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2232,20 +2298,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2015-10-11 09:39:48"
+            "time": "2015-11-23 20:38:01"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v2.7.6",
+            "version": "v2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "af284e795ec8a08c80d1fc47518fd23004b89847"
+                "reference": "1ac8ce1a1cff7ff9467d44bc71b0f71dfa751ba4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/af284e795ec8a08c80d1fc47518fd23004b89847",
-                "reference": "af284e795ec8a08c80d1fc47518fd23004b89847",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/1ac8ce1a1cff7ff9467d44bc71b0f71dfa751ba4",
+                "reference": "1ac8ce1a1cff7ff9467d44bc71b0f71dfa751ba4",
                 "shasum": ""
             },
             "require": {
@@ -2255,9 +2321,9 @@
                 "symfony/expression-language": "<2.6"
             },
             "require-dev": {
-                "symfony/config": "~2.2",
-                "symfony/expression-language": "~2.6",
-                "symfony/yaml": "~2.1"
+                "symfony/config": "~2.2|~3.0.0",
+                "symfony/expression-language": "~2.6|~3.0.0",
+                "symfony/yaml": "~2.1|~3.0.0"
             },
             "suggest": {
                 "symfony/config": "",
@@ -2267,13 +2333,16 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\DependencyInjection\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2291,20 +2360,20 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2015-10-27 15:38:06"
+            "time": "2015-11-30 06:56:28"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.7.6",
+            "version": "v2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "87a5db5ea887763fa3a31a5471b512ff1596d9b8"
+                "reference": "a5eb815363c0388e83247e7e9853e5dbc14999cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/87a5db5ea887763fa3a31a5471b512ff1596d9b8",
-                "reference": "87a5db5ea887763fa3a31a5471b512ff1596d9b8",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/a5eb815363c0388e83247e7e9853e5dbc14999cc",
+                "reference": "a5eb815363c0388e83247e7e9853e5dbc14999cc",
                 "shasum": ""
             },
             "require": {
@@ -2312,10 +2381,10 @@
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~2.0,>=2.0.5",
-                "symfony/dependency-injection": "~2.6",
-                "symfony/expression-language": "~2.6",
-                "symfony/stopwatch": "~2.3"
+                "symfony/config": "~2.0,>=2.0.5|~3.0.0",
+                "symfony/dependency-injection": "~2.6|~3.0.0",
+                "symfony/expression-language": "~2.6|~3.0.0",
+                "symfony/stopwatch": "~2.3|~3.0.0"
             },
             "suggest": {
                 "symfony/dependency-injection": "",
@@ -2324,13 +2393,16 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\EventDispatcher\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2348,20 +2420,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2015-10-11 09:39:48"
+            "time": "2015-10-30 20:15:42"
         },
         {
             "name": "symfony/finder",
-            "version": "v2.7.6",
+            "version": "v2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "2ffb4e9598db3c48eb6d0ae73b04bbf09280c59d"
+                "reference": "ead9b07af4ba77b6507bee697396a5c79e633f08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/2ffb4e9598db3c48eb6d0ae73b04bbf09280c59d",
-                "reference": "2ffb4e9598db3c48eb6d0ae73b04bbf09280c59d",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/ead9b07af4ba77b6507bee697396a5c79e633f08",
+                "reference": "ead9b07af4ba77b6507bee697396a5c79e633f08",
                 "shasum": ""
             },
             "require": {
@@ -2370,13 +2442,16 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Finder\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2394,20 +2469,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2015-10-11 09:39:48"
+            "time": "2015-10-30 20:15:42"
         },
         {
             "name": "symfony/process",
-            "version": "v2.7.6",
+            "version": "v2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "4a959dd4e19c2c5d7512689413921e0a74386ec7"
+                "reference": "1b988a88e3551102f3c2d9e1d47a18c3a78d6312"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/4a959dd4e19c2c5d7512689413921e0a74386ec7",
-                "reference": "4a959dd4e19c2c5d7512689413921e0a74386ec7",
+                "url": "https://api.github.com/repos/symfony/process/zipball/1b988a88e3551102f3c2d9e1d47a18c3a78d6312",
+                "reference": "1b988a88e3551102f3c2d9e1d47a18c3a78d6312",
                 "shasum": ""
             },
             "require": {
@@ -2416,13 +2491,16 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Process\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2440,35 +2518,38 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2015-10-23 14:47:27"
+            "time": "2015-11-30 12:35:10"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v2.7.6",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "f8ab957c17e4b85a73c4df03bdf94ee597f2bd55"
+                "reference": "6aeac8907e3e1340a0033b0a9ec075f8e6524800"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/f8ab957c17e4b85a73c4df03bdf94ee597f2bd55",
-                "reference": "f8ab957c17e4b85a73c4df03bdf94ee597f2bd55",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/6aeac8907e3e1340a0033b0a9ec075f8e6524800",
+                "reference": "6aeac8907e3e1340a0033b0a9ec075f8e6524800",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9"
+                "php": ">=5.5.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Stopwatch\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2486,20 +2567,20 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2015-10-12 12:42:24"
+            "time": "2015-10-30 23:35:59"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.7.6",
+            "version": "v2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "eca9019c88fbe250164affd107bc8057771f3f4d"
+                "reference": "f79824187de95064a2f5038904c4d7f0227fedb5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/eca9019c88fbe250164affd107bc8057771f3f4d",
-                "reference": "eca9019c88fbe250164affd107bc8057771f3f4d",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/f79824187de95064a2f5038904c4d7f0227fedb5",
+                "reference": "f79824187de95064a2f5038904c4d7f0227fedb5",
                 "shasum": ""
             },
             "require": {
@@ -2508,13 +2589,16 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Yaml\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2532,7 +2616,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2015-10-11 09:39:48"
+            "time": "2015-11-30 12:35:10"
         }
     ],
     "aliases": [],

--- a/src/Runtime/Attribute/EmailList/EmailListRule.php
+++ b/src/Runtime/Attribute/EmailList/EmailListRule.php
@@ -25,7 +25,7 @@ class EmailListRule extends Rule
 
     protected function execute($values, EntityInterface $entity = null)
     {
-        $cast_to_array = $this->toBoolean($this->getOption(self::OPTION_CAST_TO_ARRAY, true));
+        $cast_to_array = $this->getOption(self::OPTION_CAST_TO_ARRAY, true);
         if (!$cast_to_array && !is_array($values)) {
             $this->throwError('not_an_array');
             return false;

--- a/src/Runtime/Attribute/GeoPoint/GeoPointRule.php
+++ b/src/Runtime/Attribute/GeoPoint/GeoPointRule.php
@@ -49,7 +49,7 @@ class GeoPointRule extends Rule
                 return false;
             }
 
-            $treat_null_island_as_null = $this->toBoolean($this->getOption(self::OPTION_NULL_ISLAND_AS_NULL, true));
+            $treat_null_island_as_null = $this->getOption(self::OPTION_NULL_ISLAND_AS_NULL, true);
             if ($treat_null_island_as_null === true && $geopoint->isNullIsland()) {
                 // use (0,0) as NULL as that's a geocoding failure or not wanted or wanted as NULL trigger
                 $this->setSanitizedValue($null_value);

--- a/src/Runtime/Attribute/IntegerList/IntegerListRule.php
+++ b/src/Runtime/Attribute/IntegerList/IntegerListRule.php
@@ -20,8 +20,8 @@ class IntegerListRule extends Rule
             return false;
         }
 
-        $allow_hex = $this->toBoolean($this->getOption(self::OPTION_ALLOW_HEX, false));
-        $allow_octal = $this->toBoolean($this->getOption(self::OPTION_ALLOW_OCTAL, false));
+        $allow_hex = $this->getOption(self::OPTION_ALLOW_HEX, false);
+        $allow_octal = $this->getOption(self::OPTION_ALLOW_OCTAL, false);
 
         $filter_flags = 0;
         if ($allow_hex) {

--- a/src/Runtime/Validator/Rule/Type/FloatRule.php
+++ b/src/Runtime/Validator/Rule/Type/FloatRule.php
@@ -61,9 +61,9 @@ class FloatRule extends Rule
             return true;
         }
 
-        $allow_thousand = $this->toBoolean($this->getOption(self::OPTION_ALLOW_THOUSAND_SEPARATOR, false));
-        $allow_infinity = $this->toBoolean($this->getOption(self::OPTION_ALLOW_INFINITY, false));
-        $allow_nan = $this->toBoolean($this->getOption(self::OPTION_ALLOW_NAN, false));
+        $allow_thousand = $this->getOption(self::OPTION_ALLOW_THOUSAND_SEPARATOR, false);
+        $allow_infinity = $this->getOption(self::OPTION_ALLOW_INFINITY, false);
+        $allow_nan = $this->getOption(self::OPTION_ALLOW_NAN, false);
 
         $filter_flags = 0;
         if ($allow_thousand) {

--- a/src/Runtime/Validator/Rule/Type/IntegerRule.php
+++ b/src/Runtime/Validator/Rule/Type/IntegerRule.php
@@ -30,8 +30,8 @@ class IntegerRule extends Rule
             return true;
         }
 
-        $allow_hex = $this->toBoolean($this->getOption(self::OPTION_ALLOW_HEX, false));
-        $allow_octal = $this->toBoolean($this->getOption(self::OPTION_ALLOW_OCTAL, false));
+        $allow_hex = $this->getOption(self::OPTION_ALLOW_HEX, false);
+        $allow_octal = $this->getOption(self::OPTION_ALLOW_OCTAL, false);
 
         $filter_flags = 0;
         if ($allow_hex) {

--- a/src/Runtime/Validator/Rule/Type/KeyValueListRule.php
+++ b/src/Runtime/Validator/Rule/Type/KeyValueListRule.php
@@ -301,8 +301,8 @@ class KeyValueListRule extends Rule
 
     protected function getIntegerFilterFlags()
     {
-        $allow_hex = $this->toBoolean($this->getOption(IntegerAttribute::OPTION_ALLOW_HEX, false));
-        $allow_octal = $this->toBoolean($this->getOption(IntegerAttribute::OPTION_ALLOW_OCTAL, false));
+        $allow_hex = $this->getOption(IntegerAttribute::OPTION_ALLOW_HEX, false);
+        $allow_octal = $this->getOption(IntegerAttribute::OPTION_ALLOW_OCTAL, false);
 
         $filter_flags = 0;
         if ($allow_hex) {
@@ -317,9 +317,7 @@ class KeyValueListRule extends Rule
 
     protected function getFloatFilterFlags()
     {
-        $allow_thousand = $this->toBoolean(
-            $this->getOption(FloatAttribute::OPTION_ALLOW_THOUSAND_SEPARATOR, false)
-        );
+        $allow_thousand = $this->getOption(FloatAttribute::OPTION_ALLOW_THOUSAND_SEPARATOR, false);
 
         $filter_flags = 0;
         if ($allow_thousand) {

--- a/src/Runtime/Validator/Rule/Type/ListRule.php
+++ b/src/Runtime/Validator/Rule/Type/ListRule.php
@@ -15,7 +15,7 @@ class ListRule extends Rule
 
     protected function execute($value, EntityInterface $entity = null)
     {
-        $cast_to_array = $this->toBoolean($this->getOption(self::OPTION_CAST_TO_ARRAY, true));
+        $cast_to_array = $this->getOption(self::OPTION_CAST_TO_ARRAY, true);
         if ((!$cast_to_array && !is_array($value)) || (!$cast_to_array && !$value instanceof Traversable)) {
             $this->throwError('not_an_array');
             return false;

--- a/src/Runtime/Validator/Rule/Type/SanitizedFilenameRule.php
+++ b/src/Runtime/Validator/Rule/Type/SanitizedFilenameRule.php
@@ -115,7 +115,7 @@ class SanitizedFilenameRule extends Rule
         // replace multiple occurrences of '.' with one '.'
         $value = preg_replace('/\.{2,}/', '.', $value);
 
-        $replace_special_chars = $this->toBoolean($this->getOption(self::OPTION_REPLACE_SPECIAL_CHARS, true));
+        $replace_special_chars = $this->getOption(self::OPTION_REPLACE_SPECIAL_CHARS, true);
         if ($replace_special_chars) {
             $replace_chars = [
                 '#', '<', '$', '+', '%', '>', '!', '`', '&', '*', '‘',
@@ -164,7 +164,7 @@ class SanitizedFilenameRule extends Rule
             }
         }
 
-        $lowercase = $this->toBoolean($this->getOption(self::OPTION_LOWERCASE, false));
+        $lowercase = $this->getOption(self::OPTION_LOWERCASE, false);
         if ($lowercase) {
             $value = mb_strtolower($value, 'UTF-8');
             // TODO it's probably advisable to manually lowercase some more variants as mentioned
@@ -172,7 +172,7 @@ class SanitizedFilenameRule extends Rule
             //$value = strtr($value, $additional_replacements);
         }
 
-        $spoofcheck_resulting_value = $this->toBoolean($this->getOption(self::OPTION_SPOOFCHECK_RESULT, false));
+        $spoofcheck_resulting_value = $this->getOption(self::OPTION_SPOOFCHECK_RESULT, false);
         if ($spoofcheck_resulting_value) {
             $rule = new SpoofcheckerRule('spoofcheck-resulting-text', $this->getOptions());
             if (!$rule->apply($value)) {

--- a/src/Runtime/Validator/Rule/Type/SpoofcheckerRule.php
+++ b/src/Runtime/Validator/Rule/Type/SpoofcheckerRule.php
@@ -45,7 +45,7 @@ class SpoofcheckerRule extends Rule
             return false;
         }
 
-        $ignore_missing_class = $this->toBoolean($this->getOption(self::OPTION_IGNORE_MISSING_CLASS, false));
+        $ignore_missing_class = $this->getOption(self::OPTION_IGNORE_MISSING_CLASS, false);
         $spoofchecker_available = extension_loaded('intl') && class_exists("Spoofchecker");
         if (!$spoofchecker_available) {
             if ($ignore_missing_class) {
@@ -59,7 +59,7 @@ class SpoofcheckerRule extends Rule
 
         // check if a string is suspicious, e.g. containing multiple scripts
         $is_suspicious = false;
-        $accept_suspicious_strings = $this->toBoolean($this->getOption(self::OPTION_ACCEPT_SUSPICIOUS_STRINGS, false));
+        $accept_suspicious_strings = $this->getOption(self::OPTION_ACCEPT_SUSPICIOUS_STRINGS, false);
         if (!$accept_suspicious_strings) {
             $spoofchecker = $this->getSuspiciousChecker();
             $is_suspicious = $spoofchecker->isSuspicious($value, $error);
@@ -125,7 +125,7 @@ class SpoofcheckerRule extends Rule
         $checks = Spoofchecker::SINGLE_SCRIPT_CONFUSABLE | Spoofchecker::MIXED_SCRIPT_CONFUSABLE;
 
         // find confusable characters of any case?
-        $any_case_confusable = $this->toBoolean($this->getOption(self::OPTION_ANY_CASE_CONFUSABLE, true));
+        $any_case_confusable = $this->getOption(self::OPTION_ANY_CASE_CONFUSABLE, true);
         if ($any_case_confusable) {
             /**
              * ANY_CASE is a modifier for the *_SCRIPT_CONFUSABLE checks.
@@ -140,9 +140,7 @@ class SpoofcheckerRule extends Rule
         }
 
         // reject zero-width space, non-spacing mark etc.
-        $reject_invisible_characters = $this->toBoolean(
-            $this->getOption(self::OPTION_REJECT_INVISIBLE_CHARACTERS, true)
-        );
+        $reject_invisible_characters = $this->getOption(self::OPTION_REJECT_INVISIBLE_CHARACTERS, true);
         if ($reject_invisible_characters) {
             /**
              * Do not allow the presence of invisible characters, such as zero-width spaces, or character sequences
@@ -152,7 +150,7 @@ class SpoofcheckerRule extends Rule
         }
 
         // enforce a single script instead of allowing multiple when they're not confusable/suspicious?
-        $enforce_single_script = $this->toBoolean($this->getOption(self::OPTION_ENFORCE_SINGLE_SCRIPT, false));
+        $enforce_single_script = $this->getOption(self::OPTION_ENFORCE_SINGLE_SCRIPT, false);
         if ($enforce_single_script) {
             /**
              * Single-script enforcement is turned off in the Spoofchecker class by default as it fails
@@ -196,7 +194,7 @@ class SpoofcheckerRule extends Rule
             Spoofchecker::WHOLE_SCRIPT_CONFUSABLE;
 
         // find confusable characters of any case?
-        $any_case_confusable = $this->toBoolean($this->getOption(self::OPTION_ANY_CASE_CONFUSABLE, true));
+        $any_case_confusable = $this->getOption(self::OPTION_ANY_CASE_CONFUSABLE, true);
         if ($any_case_confusable) {
             /**
              * ANY_CASE is a modifier for the *_SCRIPT_CONFUSABLE checks.
@@ -211,9 +209,7 @@ class SpoofcheckerRule extends Rule
         }
 
         // reject zero-width space, non-spacing mark etc.? those characters are suspicious anyways…
-        $reject_invisible_characters = $this->toBoolean(
-            $this->getOption(self::OPTION_REJECT_INVISIBLE_CHARACTERS, true)
-        );
+        $reject_invisible_characters = $this->getOption(self::OPTION_REJECT_INVISIBLE_CHARACTERS, true);
         if ($reject_invisible_characters) {
             /**
              * Do not allow the presence of invisible characters, such as zero-width spaces, or character sequences
@@ -223,7 +219,7 @@ class SpoofcheckerRule extends Rule
         }
 
         // enforce a single script instead of allowing multiple when they're not confusable/suspicious?
-        $enforce_single_script = $this->toBoolean($this->getOption(self::OPTION_ENFORCE_SINGLE_SCRIPT, false));
+        $enforce_single_script = $this->getOption(self::OPTION_ENFORCE_SINGLE_SCRIPT, false);
         if ($enforce_single_script) {
             /**
              * Single-script enforcement is turned off in the Spoofchecker class by default as it fails

--- a/src/Runtime/Validator/Rule/Type/TextRule.php
+++ b/src/Runtime/Validator/Rule/Type/TextRule.php
@@ -115,7 +115,8 @@ class TextRule extends Rule
             ini_set('mbstring.substitute_character', $prev);
         }
 
-        // trim the input string if necessary – this might actually not trim a lot when invalid utf8 is left from prior steps
+        // trim the input string if necessary
+        // this might actually not trim a lot when invalid utf8 is left from prior steps
         if ($this->getOption(self::OPTION_TRIM, true)) {
             //$value = trim($value);
             // note: '/(*UTF8)[[:alnum:]]/' matches 'é' while '/[[:alnum:]]/' does not

--- a/src/Runtime/Validator/Rule/Type/TextRule.php
+++ b/src/Runtime/Validator/Rule/Type/TextRule.php
@@ -44,7 +44,7 @@ class TextRule extends Rule
             return false;
         }
 
-        $spoofcheck_incoming_value = $this->toBoolean($this->getOption(self::OPTION_SPOOFCHECK_INCOMING, false));
+        $spoofcheck_incoming_value = $this->getOption(self::OPTION_SPOOFCHECK_INCOMING, false);
         if ($spoofcheck_incoming_value) {
             $rule = new SpoofcheckerRule('spoofcheck-incoming-text', $this->getOptions());
             if (!$rule->apply($value)) {
@@ -58,19 +58,19 @@ class TextRule extends Rule
         }
 
         // @see http://hakipedia.com/index.php/Poison_Null_Byte
-        $strip_null_bytes = $this->toBoolean($this->getOption(self::OPTION_STRIP_NULL_BYTES, true));
+        $strip_null_bytes = $this->getOption(self::OPTION_STRIP_NULL_BYTES, true);
         if ($strip_null_bytes) {
             $value = str_replace(chr(0), '', $value);
         }
 
         // remove zero-width space character from text
-        $strip_zero_width_space = $this->toBoolean($this->getOption(self::OPTION_STRIP_ZERO_WIDTH_SPACE, false));
+        $strip_zero_width_space = $this->getOption(self::OPTION_STRIP_ZERO_WIDTH_SPACE, false);
         if ($strip_zero_width_space) {
             $value = str_replace("\xE2\x80\x8B", '', $value);
         }
 
         // strip unicode characters 'RIGHT-TO-LEFT OVERRIDE' and 'LEFT-TO-RIGHT OVERRIDE' if necessary
-        $strip_direction_overrides = $this->toBoolean($this->getOption(self::OPTION_STRIP_DIRECTION_OVERRIDES, false));
+        $strip_direction_overrides = $this->getOption(self::OPTION_STRIP_DIRECTION_OVERRIDES, false);
         if ($strip_direction_overrides) {
             $value = str_replace("\xE2\x80\xAE", '', $value); // 'RIGHT-TO-LEFT OVERRIDE'
             $value = str_replace("\xE2\x80\xAD", '', $value); // 'LEFT-TO-RIGHT OVERRIDE'
@@ -88,7 +88,7 @@ class TextRule extends Rule
          */
 
         // check for a valid utf8 string without certain byte sequences
-        $reject_invalid_utf8 = $this->toBoolean($this->getOption(self::OPTION_REJECT_INVALID_UTF8, true));
+        $reject_invalid_utf8 = $this->getOption(self::OPTION_REJECT_INVALID_UTF8, true);
         if ($reject_invalid_utf8) {
             if (!mb_check_encoding($value, 'UTF-8')) {
                 $this->throwError(
@@ -104,7 +104,7 @@ class TextRule extends Rule
         }
 
         // strip invalid utf8 characters
-        $strip_invalid_utf8 = $this->toBoolean($this->getOption(self::OPTION_STRIP_INVALID_UTF8, true));
+        $strip_invalid_utf8 = $this->getOption(self::OPTION_STRIP_INVALID_UTF8, true);
         if ($strip_invalid_utf8) {
             // use mbstring here instead of iconv with '//ignore' – https://bugs.php.net/bug.php?id=61484
             // $value = iconv('UTF-8', 'UTF-8//IGNORE', $value);
@@ -115,6 +115,7 @@ class TextRule extends Rule
 
         // trim the input string if necessary
         if ($this->getOption(self::OPTION_TRIM, true)) {
+            //$value = trim($value);
             // note: '/(*UTF8)[[:alnum:]]/' matches 'é' while '/[[:alnum:]]/' does not
             $pattern = '/(*UTF8)^[\pZ\pC]*+(?P<trimmed>.*?)[\pZ\pC]*+$/usDS';
             if (preg_match($pattern, $value, $matches)) {
@@ -125,7 +126,7 @@ class TextRule extends Rule
         $sanitized_value = $value;
 
         // additionally remove some control characters
-        $strip_ctrl_chars = $this->toBoolean($this->getOption(self::OPTION_STRIP_CONTROL_CHARACTERS, true));
+        $strip_ctrl_chars = $this->getOption(self::OPTION_STRIP_CONTROL_CHARACTERS, true);
         if ($strip_ctrl_chars) {
             // remove non-printable control characters, but MAYBE allow TAB, LINE FEED, CARRIAGE RETURN
             // $remove_pattern = "/[\x01-\x08\x09\x0A\x0B\x0C\x0D\x0E-\x1F\x7F]/u";
@@ -136,12 +137,12 @@ class TextRule extends Rule
                 "\x1C", "\x1D", "\x1E", "\x1F", "\x7F"
             ];
 
-            $allow_tab = $this->toBoolean($this->getOption(self::OPTION_ALLOW_TAB, true));
+            $allow_tab = $this->getOption(self::OPTION_ALLOW_TAB, true);
             if ($allow_tab) {
                 unset($remove_chars[8]); // "\x09"
             }
 
-            $allow_crlf = $this->toBoolean($this->getOption(self::OPTION_ALLOW_CRLF, false));
+            $allow_crlf = $this->getOption(self::OPTION_ALLOW_CRLF, false);
             if ($allow_crlf) {
                 unset($remove_chars[9]); // "\x0A"
                 unset($remove_chars[12]); // "\x0D"
@@ -154,7 +155,7 @@ class TextRule extends Rule
             }
         }
 
-        $normalize_newlines = $this->toBoolean($this->getOption(self::OPTION_NORMALIZE_NEWLINES, false));
+        $normalize_newlines = $this->getOption(self::OPTION_NORMALIZE_NEWLINES, false);
         if ($normalize_newlines) {
             $sanitized_value = str_replace(["\r\n", "\r"], "\n", $sanitized_value);
             if (!is_string($sanitized_value)) {
@@ -193,7 +194,7 @@ class TextRule extends Rule
             }
         }
 
-        $spoofcheck_resulting_value = $this->toBoolean($this->getOption(self::OPTION_SPOOFCHECK_RESULT, false));
+        $spoofcheck_resulting_value = $this->getOption(self::OPTION_SPOOFCHECK_RESULT, false);
         if ($spoofcheck_resulting_value) {
             $rule = new SpoofcheckerRule('spoofcheck-resulting-text', $this->getOptions());
             if (!$rule->apply($sanitized_value)) {

--- a/src/Runtime/Validator/Rule/Type/UrlRule.php
+++ b/src/Runtime/Validator/Rule/Type/UrlRule.php
@@ -110,7 +110,7 @@ class UrlRule extends Rule
         }
 
         $null_value = $this->getOption(AttributeInterface::OPTION_NULL_VALUE, '');
-        $mandatory = $this->toBoolean($this->getOption(self::OPTION_MANDATORY, false));
+        $mandatory = $this->getOption(self::OPTION_MANDATORY, false);
         if (!$mandatory && $value === $null_value) {
             // parse_url with empty string doesn't return false but 'path' being an empty string
             $this->setSanitizedValue($null_value);
@@ -238,44 +238,44 @@ class UrlRule extends Rule
 
         // check for required parts according to existing options
 
-        $require_user = $this->toBoolean($this->getOption(self::OPTION_REQUIRE_USER, false));
+        $require_user = $this->getOption(self::OPTION_REQUIRE_USER, false);
         if ($require_user && !array_key_exists('user', $url_parts)) {
             $this->throwError('user_part_missing', [ 'value' => $val ]);
             return false;
         }
 
-        $require_pass = $this->toBoolean($this->getOption(self::OPTION_REQUIRE_PASS, false));
+        $require_pass = $this->getOption(self::OPTION_REQUIRE_PASS, false);
         if ($require_pass && !array_key_exists('pass', $url_parts)) {
             $this->throwError('pass_part_missing', [ 'value' => $val ]);
             return false;
         }
 
-        $require_port = $this->toBoolean($this->getOption(self::OPTION_REQUIRE_PORT, false));
+        $require_port = $this->getOption(self::OPTION_REQUIRE_PORT, false);
         if ($require_port && !array_key_exists('port', $url_parts)) {
             $this->throwError('port_part_missing', [ 'value' => $val ]);
             return false;
         }
 
-        $require_path = $this->toBoolean($this->getOption(self::OPTION_REQUIRE_PATH, false));
+        $require_path = $this->getOption(self::OPTION_REQUIRE_PATH, false);
         if ($require_path && !array_key_exists('path', $url_parts)) {
             $this->throwError('path_part_missing', [ 'value' => $val ]);
             return false;
         }
 
-        $require_query = $this->toBoolean($this->getOption(self::OPTION_REQUIRE_QUERY, false));
+        $require_query = $this->getOption(self::OPTION_REQUIRE_QUERY, false);
         if ($require_query && !array_key_exists('query', $url_parts)) {
             $this->throwError('query_part_missing', [ 'value' => $val ]);
             return false;
         }
 
-        $require_fragment = $this->toBoolean($this->getOption(self::OPTION_REQUIRE_FRAGMENT, false));
+        $require_fragment = $this->getOption(self::OPTION_REQUIRE_FRAGMENT, false);
         if ($require_fragment && !array_key_exists('fragment', $url_parts)) {
             $this->throwError('fragment_part_missing', [ 'value' => $val ]);
             return false;
         }
 
-        $use_idn = $this->toBoolean($this->getOption(self::OPTION_USE_IDN, true));
-        $convert_host_to_punycode = $this->toBoolean($this->getOption(self::OPTION_CONVERT_HOST_TO_PUNYCODE, false));
+        $use_idn = $this->getOption(self::OPTION_USE_IDN, true);
+        $convert_host_to_punycode = $this->getOption(self::OPTION_CONVERT_HOST_TO_PUNYCODE, false);
         $idn_available = function_exists('idn_to_ascii') ? true : false;
         if (!$idn_available && $use_idn) {
             throw new RuntimeException(
@@ -325,8 +325,8 @@ class UrlRule extends Rule
          * @see http://www.unicode.org/Public/security/revision-06/confusables.txt
          * @see http://icu-project.org/apiref/icu4j50m1/com/ibm/icu/text/SpoofChecker.html for docs on constants
          */
-        $accept_suspicious_host = $this->toBoolean($this->getOption(self::OPTION_ACCEPT_SUSPICIOUS_HOST, true));
-        $convert_suspicious_host = $this->toBoolean($this->getOption(self::OPTION_CONVERT_SUSPICIOUS_HOST, true));
+        $accept_suspicious_host = $this->getOption(self::OPTION_ACCEPT_SUSPICIOUS_HOST, true);
+        $convert_suspicious_host = $this->getOption(self::OPTION_CONVERT_SUSPICIOUS_HOST, true);
         $spoofchecker_available = extension_loaded('intl') && class_exists("Spoofchecker");
         if ((!$spoofchecker_available && $convert_suspicious_host) ||
             (!$spoofchecker_available && !$accept_suspicious_host)
@@ -371,10 +371,10 @@ class UrlRule extends Rule
         $punycode_url = $this->getUrlFromArray($punycode_url_parts);
 
         $filter_flags = 0;
-        if ($this->toBoolean(self::OPTION_REQUIRE_PATH, false)) {
+        if ($this->getOption(self::OPTION_REQUIRE_PATH, false)) {
             $filter_flags |= FILTER_FLAG_PATH_REQUIRED;
         }
-        if ($this->toBoolean(self::OPTION_REQUIRE_QUERY, false)) {
+        if ($this->getOption(self::OPTION_REQUIRE_QUERY, false)) {
             $filter_flags |= FILTER_FLAG_QUERY_REQUIRED;
         }
 

--- a/src/Runtime/Validator/Rule/Type/UuidRule.php
+++ b/src/Runtime/Validator/Rule/Type/UuidRule.php
@@ -19,7 +19,7 @@ class UuidRule extends Rule
             return false;
         }
 
-        $trim = $this->toBoolean($this->getOption(self::OPTION_TRIM, false));
+        $trim = $this->getOption(self::OPTION_TRIM, false);
         if ($trim) {
             $value = trim($value);
         }

--- a/tests/CreateEntityPerformance.php
+++ b/tests/CreateEntityPerformance.php
@@ -9,10 +9,14 @@ require_once dirname(__DIR__) . '/vendor/autoload.php';
 $data = [
     'uuid' => '7e185d43-f870-46e7-9cea-59800555e970',
     'headline' => 'this is a short headline',
-    'content' => "Like you, I used to think the world was this great place where everybody lived by the same standards I did, then some kid with a nail showed me I was living in his world, a world where chaos rules not order, a world where righteousness is not rewarded. That's Cesar's world, and if you're not willing to play by his rules, then you're gonna have to pay the price.
-
-    Well, the way they make shows is, they make one show. That show's called a pilot. Then they show that show to the people who make shows, and on the strength of that one show they decide if they're going to make more shows. Some pilots get picked and become television programs. Some don't, become nothing. She starred in one of the ones that became nothing.
-",
+    'content' => "Like you, I used to think the world was this great place where everybody lived by the same" .
+        " standards I did, then some kid with a nail showed me I was living in his world, a world where chaos rules" .
+        " not order, a world where righteousness is not rewarded. That's Cesar's world, and if you're not willing to" .
+        " play by his rules, then you're gonna have to pay the price. \n\n    Well, the way they make shows is, they" .
+        " make one show. That show's called a pilot. Then they show that show to the people who make shows, and on" .
+        " the strength of that one show they decide if they're going to make more shows. Some pilots get picked" .
+        " and become television programs. Some don't, become nothing. She starred in one of the ones that became" .
+        "nothing.\n",
     'click_count' => 123,
     'float' => 123.456,
     'coords' => [ 'lon' => 123.456, 'lat' => 52.34 ],
@@ -27,14 +31,21 @@ $data = [
         [
             '@type' => 'paragraph',
             'title' => 'hello world!',
-            'text' => " You see? It's curious. Ted did figure it out - time travel. And when we get back, we gonna tell everyone. How it's possible, how it's done, what the dangers are. But then why fifty years in the future when the spacecraft encounters a black hole does the computer call it an 'unknown entry event'? Why don't they know? If they don't know, that means we never told anyone. And if we never told anyone it means we never made it back. Hence we die down here. Just as a matter of deductive logic.
-",
+            'text' => " You see? It's curious. Ted did figure it out - time travel. And when we get back, we gonna" .
+                " tell everyone. How it's possible, how it's done, what the dangers are. But then why fifty years" .
+                " in the future when the spacecraft encounters a black hole does the computer call it an 'unknown" .
+                " entry event'? Why don't they know? If they don't know, that means we never told anyone. And if" .
+                " we never told anyone it means we never made it back. Hence we die down here. Just as a matter of" .
+                " deductive logic.\n",
             'coords' => [ 'lon' => 12.34, 'lat' => 56.78 ]
         ],
         [
             '@type' => 'paragraph',
             'title' => 'hello world again!',
-            'text' => " Now that we know who you are, I know who I am. I'm not a mistake! It all makes sense! In a comic, you know how you can tell who the arch-villain's going to be? He's the exact opposite of the hero. And most times they're friends, like you and me! I should've known way back when... You know why, David? Because of the kids. They called me Mr Glass. ",
+            'text' => " Now that we know who you are, I know who I am. I'm not a mistake! It all makes sense! In" .
+                " a comic, you know how you can tell who the arch-villain's going to be? He's the exact opposite" .
+                " of the hero. And most times they're friends, like you and me! I should've known way back when..." .
+                " You know why, David? Because of the kids. They called me Mr Glass. ",
             'coords' => [ 'lon' => 23.45, 'lat' => 56.78 ]
         ]
     ],

--- a/tests/CreateEntityPerformance.php
+++ b/tests/CreateEntityPerformance.php
@@ -1,0 +1,91 @@
+#!/usr/bin/env php
+<?php
+
+use Trellis\Tests\Runtime\Fixtures\ArticleType;
+
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+// same order as in ArticleType definition!
+$data = [
+    'uuid' => '7e185d43-f870-46e7-9cea-59800555e970',
+    'headline' => 'this is a short headline',
+    'content' => "Like you, I used to think the world was this great place where everybody lived by the same standards I did, then some kid with a nail showed me I was living in his world, a world where chaos rules not order, a world where righteousness is not rewarded. That's Cesar's world, and if you're not willing to play by his rules, then you're gonna have to pay the price.
+
+    Well, the way they make shows is, they make one show. That show's called a pilot. Then they show that show to the people who make shows, and on the strength of that one show they decide if they're going to make more shows. Some pilots get picked and become television programs. Some don't, become nothing. She starred in one of the ones that became nothing.
+",
+    'click_count' => 123,
+    'float' => 123.456,
+    'coords' => [ 'lon' => 123.456, 'lat' => 52.34 ],
+    'author' => 'Samuel L Ipsum',
+    'email' => 'samuel.l.ipsum@example.com',
+    'website' => 'http://slipsum.com/lite/',
+    'birthday' => '2014-12-31T12:34:56.123456+01:00',
+    'images' => [ 1, 2, 3, 4, 5, 6 ],
+    'keywords' => [ 'some', 'keywords' ],
+    'enabled' => true,
+    'content_objects' => [
+        [
+            '@type' => 'paragraph',
+            'title' => 'hello world!',
+            'text' => " You see? It's curious. Ted did figure it out - time travel. And when we get back, we gonna tell everyone. How it's possible, how it's done, what the dangers are. But then why fifty years in the future when the spacecraft encounters a black hole does the computer call it an 'unknown entry event'? Why don't they know? If they don't know, that means we never told anyone. And if we never told anyone it means we never made it back. Hence we die down here. Just as a matter of deductive logic.
+",
+            'coords' => [ 'lon' => 12.34, 'lat' => 56.78 ]
+        ],
+        [
+            '@type' => 'paragraph',
+            'title' => 'hello world again!',
+            'text' => " Now that we know who you are, I know who I am. I'm not a mistake! It all makes sense! In a comic, you know how you can tell who the arch-villain's going to be? He's the exact opposite of the hero. And most times they're friends, like you and me! I should've known way back when... You know why, David? Because of the kids. They called me Mr Glass. ",
+            'coords' => [ 'lon' => 23.45, 'lat' => 56.78 ]
+        ]
+    ],
+    'categories'=> [
+        [
+            '@type' => 'referenced_category',
+            'identifier' => '1023abf5-f870-46e7-9cea-5980055a523b',
+            'referenced_identifier' => 'some-category'
+        ]
+    ],
+    'meta' => [
+        'key' => 'value'
+    ],
+    'workflow_state' => []
+];
+
+
+$times = [];
+
+$num = 10;
+$repeats = 1000;
+
+$article_type = new ArticleType();
+for ($t = 0; $t < $num; $t++) {
+    $start = microtime(true);
+    for ($i = 0; $i < $repeats; $i++) {
+        $article = $article_type->createEntity($data);
+    }
+    $end = microtime(true);
+    $times[$t] = round(($end - $start) * 1000, 3);
+    echo $times[$t] . 'ms ';
+}
+
+$sum = 0;
+for ($i = 0; $i < $num; $i++) {
+    $sum += $times[$i];
+}
+
+echo PHP_EOL . 'Average time to create ' . $repeats . ' articles: ' . round($sum / $num, 3) . PHP_EOL;
+
+// default: avg=4692ms for 1000 articles, 4668ms, 4709ms
+// default w/ bool cast in toBoolean of Rule: avg=4503ms for 1000 articles, 4491ms
+// default w/o toBoolean: avg=4355ms for 1000 articles, 4348ms
+// default w/o toBoolean and w/ simple trim(): avg=4323ms for 1000 articles, 4356ms
+//
+// ~ 7% improvement for 1000 articles when not using toBoolean for getOption()
+//
+// default w/o toBoolean in TextRule: avg=4401ms for 1000 articles, 4395
+// default w/o toBoolean and w/o strip_ctrl_chars in TextRule: avg=4034ms for 1000 articles, 4061
+// default w/ trim instead of regexp in TextRule: avg=4457ms for 1000 articles, 4430, 4476
+// default w/ trim and w/o toBoolean in TextRule: avg=4229ms for 1000 articles
+// default w/ bool cast: avg=4247ms for 1000 articles
+// bool cast instead of filter_var and is_string validation: avg=3240ms for 1000 articles, 3174
+//

--- a/tests/Runtime/Attribute/Text/TextAttributeTest.php
+++ b/tests/Runtime/Attribute/Text/TextAttributeTest.php
@@ -24,7 +24,8 @@ class TextAttributeTest extends TestCase
         $text_attribute = new TextAttribute(self::ATTR_NAME, $this->getTypeMock());
         $valueholder = $text_attribute->createValueHolder();
         $result = $valueholder->setValue($string);
-        $this->assertTrue($string_trimmed === $valueholder->getValue(), 'utf8 string should be trimmed');
+        // $this->assertTrue($string_trimmed === $valueholder->getValue(), 'utf8 string should be trimmed');
+        $this->assertSame($string_trimmed, $valueholder->getValue(), 'utf8 string should be trimmed');
     }
 
     /**

--- a/tests/Runtime/Validator/Rule/Type/TextRuleTest.php
+++ b/tests/Runtime/Validator/Rule/Type/TextRuleTest.php
@@ -32,6 +32,28 @@ class TextRuleTest extends TestCase
         $this->assertEquals("foo\t\r\nbar", $rule->getSanitizedValue());
     }
 
+    public function testUtf8TrimWorks()
+    {
+        $s = html_entity_decode(" Hello &#160; ");
+        $rule = new TextRule('text', []);
+        $valid = $rule->apply($s);
+        $this->assertSame("Hello", $rule->getSanitizedValue());
+    }
+
+/*    public function testTrimAfterInvalidUtf8StrippingWorks()
+    {
+        $s = "  \xc3\x28a\n \t\n \r\n   "; // invalid 2 octet sequence with some whitespace around
+        $rule = new TextRule('text', [
+            TextRule::OPTION_REJECT_INVALID_UTF8 => false,
+            TextRule::OPTION_STRIP_INVALID_UTF8 => true,
+            TextRule::OPTION_TRIM => true,
+        ]);
+        $valid = $rule->apply($s);
+        $this->assertTrue($valid);
+        $this->assertSame("a", $rule->getSanitizedValue());
+    }
+*/
+
     public function testNewlinesCanBeNormalized()
     {
         $rule = new TextRule('text', [

--- a/tests/TextRulePerformance.php
+++ b/tests/TextRulePerformance.php
@@ -33,6 +33,8 @@ echo PHP_EOL . 'Average time for ' . $repeats . ' text rule validations: ' . rou
 // String: ' this is a test string w/o very special characters… ' & the same x20
 // is_string only in TextRule: avg=183ms => w/ 20x longer text: avg=183ms
 //
+// preg_match => 10049.92 – preg_replace => 11683.078 – replace ".*?" with "[^\pC\pZ]*" => 5148ms (but breaks the tests)
+//
 // default options on trimmable string: avg=3267ms 3205ms => w/ 20x longer text: avg=10290ms
 // default options on trimmable string w/o toBoolean: avg=2660ms, 2690ms => w/ 20x longer text: avg=9777ms, 9885ms
 // default options on trimmable string w/o toBoolean and simple trim(): avg=2066ms, 2100ms => w/ 20x longer text: avg=4362ms, 4415ms

--- a/tests/TextRulePerformance.php
+++ b/tests/TextRulePerformance.php
@@ -12,11 +12,13 @@ $times = [];
 $num = 10;
 $repeats = 100000;
 
+$string = ' this is a test string w/o very special characters… ';
+$string_x20 = str_repeat($string, 20);
+
 for ($t = 0; $t < $num; $t++) {
     $start = microtime(true);
     for ($i = 0; $i < $repeats; $i++) {
-        //$rule->apply(' this is a test string w/o very special characters… ');
-        $rule->apply(' this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters… ');
+        $rule->apply($string_x20);
     }
     $end = microtime(true);
     $times[$t] = round(($end - $start) * 1000, 3);
@@ -33,11 +35,11 @@ echo PHP_EOL . 'Average time for ' . $repeats . ' text rule validations: ' . rou
 // String: ' this is a test string w/o very special characters… ' & the same x20
 // is_string only in TextRule: avg=183ms => w/ 20x longer text: avg=183ms
 //
-// preg_match => 10049.92 – preg_replace => 11683.078 – replace ".*?" with "[^\pC\pZ]*" => 5148ms (but breaks the tests)
+// preg_match => 10049.92 – preg_replace => 11683.078 – replace ".*?" with "[^\pC\pZ]*" => 5148ms (tests fail)
 //
 // default options on trimmable string: avg=3267ms 3205ms => w/ 20x longer text: avg=10290ms
 // default options on trimmable string w/o toBoolean: avg=2660ms, 2690ms => w/ 20x longer text: avg=9777ms, 9885ms
-// default options on trimmable string w/o toBoolean and simple trim(): avg=2066ms, 2100ms => w/ 20x longer text: avg=4362ms, 4415ms
+// default options on trimmable string w/o toBoolean and simple trim(): avg=2066ms, 2100ms => w/ 20x: avg=4362ms/4415ms
 //
 // w/o toBoolean: ~18% faster on short text, 5% on 20x longer text
 // w/o toBoolean and w/ trim(): ~36,7%, ~34,5% on short text, ~57,6%, 57,1% on 20x longer text

--- a/tests/TextRulePerformance.php
+++ b/tests/TextRulePerformance.php
@@ -1,0 +1,42 @@
+#!/usr/bin/env php
+<?php
+
+use Trellis\Runtime\Validator\Rule\Type\TextRule;
+
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+$rule = new TextRule('text', []);
+
+$times = [];
+
+$num = 10;
+$repeats = 100000;
+
+for ($t = 0; $t < $num; $t++) {
+    $start = microtime(true);
+    for ($i = 0; $i < $repeats; $i++) {
+        //$rule->apply(' this is a test string w/o very special characters… ');
+        $rule->apply(' this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters…  this is a test string w/o very special characters… ');
+    }
+    $end = microtime(true);
+    $times[$t] = round(($end - $start) * 1000, 3);
+    echo $times[$t] . 'ms ';
+}
+
+$sum = 0;
+for ($i = 0; $i < $num; $i++) {
+    $sum += $times[$i];
+}
+
+echo PHP_EOL . 'Average time for ' . $repeats . ' text rule validations: ' . round($sum / $num, 3) . PHP_EOL;
+
+// String: ' this is a test string w/o very special characters… ' & the same x20
+// is_string only in TextRule: avg=183ms => w/ 20x longer text: avg=183ms
+//
+// default options on trimmable string: avg=3267ms 3205ms => w/ 20x longer text: avg=10290ms
+// default options on trimmable string w/o toBoolean: avg=2660ms, 2690ms => w/ 20x longer text: avg=9777ms, 9885ms
+// default options on trimmable string w/o toBoolean and simple trim(): avg=2066ms, 2100ms => w/ 20x longer text: avg=4362ms, 4415ms
+//
+// w/o toBoolean: ~18% faster on short text, 5% on 20x longer text
+// w/o toBoolean and w/ trim(): ~36,7%, ~34,5% on short text, ~57,6%, 57,1% on 20x longer text
+//


### PR DESCRIPTION
See https://github.com/honeybee/trellis/issues/14

This PR removes the `toBoolean()` calls around `$this->getOption()` calls in validation rules. This improves the performance quite a bit by "only" losing on the functionality of having string `"false"` interpreted as `false` for boolean options in rules.

For `ArticleType->createEntity()` this is about 7% faster (1000 articles created). The `TextRule` apply is about 18% faster on short text and ~5% faster on a 20x longer text.
